### PR TITLE
fix: example domain inconsistency

### DIFF
--- a/content/user-manual/feed-syndication/index.md
+++ b/content/user-manual/feed-syndication/index.md
@@ -78,7 +78,7 @@ curl 'https://vulnerability.circl.lu/sightings/feed.atom?vulnerability=CVE-2024-
 ### Recent sightings related to a product
 
 ```bash
-curl 'http://127.0.0.1:5000/sightings/cpesearch/cpe:2.3:a:linux:linux:*:*:*:*:*:*:*:*/feed.atom'
+curl 'https://vulnerability.circl.lu/sightings/cpesearch/cpe:2.3:a:linux:linux:*:*:*:*:*:*:*:*/feed.atom'
 ```
 
 This will return recent sightings related to recent CVEs for the specified product (identified by its CPE identifier). Sightings are based on information from various trusted sources, including security websites, Exploit-DB.com, GitHub repositories, security blogs, social networks, and MISP.


### PR DESCRIPTION
All domains should be the same in the documentation or there should be an explanation why another one is used